### PR TITLE
Support only GPUs capable of OpenCL 2.0+

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sloth256-189"
-version = "0.4.1"
+version = "0.4.2"
 description = "Encoder/decoder for the Subspace Network Blockchain based on the SLOTH permutation"
 authors = [
     # CPU implementation in C and x86-64 Assembly


### PR DESCRIPTION
Mesa's Clover was skipped before, but as Simon suggested in https://github.com/subspace/sloth256-189/pull/14#discussion_r901964696, we should instead just check more generally for OpenCL 2 support instead, which this PR achieves.

Didn't test on corresponding device, but I believe this fixes #29.

@i1i1 and @ozgunozerk if you can do basic testing on this with various GPUs that'd help.